### PR TITLE
chore(ci): publishes to npm on new release

### DIFF
--- a/.github/workflows/publish-to-npm-on-release.yml
+++ b/.github/workflows/publish-to-npm-on-release.yml
@@ -1,0 +1,30 @@
+name: Publish to npm on release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+    - name: Installing dependencies
+      run: npm ci
+    - name: Running tests
+      run: npm test
+  
+  npm-publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - run: npm publish
+      env: 
+        NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      


### PR DESCRIPTION
Adds a new CI hook that triggers on new releases. It automatically pushes the new release to the npm registry.