### PR TITLE
fix: removes unnecessary git add after linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     },
     "lint-staged": {
         "*.js": [
-            "npm run lint -- --fix",
-            "git add"
+            "npm run lint -- --fix"
         ]
     }
 }


### PR DESCRIPTION
This is not required after the update of `lint-staged` to the latest version.